### PR TITLE
Update for eForms

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Adds an object to describe the date, time, place and other details of the bid opening.
 
+If you are using the [Lots extension](https://extensions.open-contracting.org/en/extensions/lots/master/), [follow its guidance](https://extensions.open-contracting.org/en/extensions/lots/master/#usage) on whether to use `tender.lots` fields or `tender` fields.
+
 ## Legal context
 
 In the European Union, this extension's fields correspond to [eForms BT-132 (Public Opening Date), BT-133 (Public Opening Place), BT-134 (Public Opening Description)](https://github.com/eForms/eForms). See [OCDS for the European Union](http://standard.open-contracting.org/profiles/eu/master/en/) for the correspondences to Tenders Electronic Daily (TED).

--- a/README.md
+++ b/README.md
@@ -4,9 +4,11 @@ Adds an object to describe the date, time, place and other details of the bid op
 
 ## Legal context
 
-In the European Union, this extension's fields correspond to [eForms BT-132, BT-133, BT-134](https://github.com/eForms/eForms). See [OCDS for the European Union](http://standard.open-contracting.org/profiles/eu/master/en/) for the correspondences to Tenders Electronic Daily (TED).
+In the European Union, this extension's fields correspond to [eForms BT-132 (Public Opening Date), BT-133 (Public Opening Place), BT-134 (Public Opening Description)](https://github.com/eForms/eForms). See [OCDS for the European Union](http://standard.open-contracting.org/profiles/eu/master/en/) for the correspondences to Tenders Electronic Daily (TED).
 
 ## Example
+
+### Tender
 
 ```json
 {
@@ -43,11 +45,56 @@ In the European Union, this extension's fields correspond to [eForms BT-132, BT-
 }
 ```
 
+### Lots
+
+```json
+{
+  "tender": {
+    "lots": [
+      {
+        "bidOpening": {
+          "date": "2019-10-16T15:00:00+01:00",
+          "address": {
+            "streetAddress": "Town Hall, St Aldate's",
+            "region": "Oxfordshire",
+            "locality": "Oxford",
+            "postalCode": "OX1 1BX",
+            "countryName": "United Kingdom"
+          },
+          "location": {
+            "description": "Central Oxford",
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                51.751944,
+                -1.257778
+              ]
+            },
+            "gazetteer": {
+              "scheme": "GEONAMES",
+              "identifiers": [
+                "2640729"
+              ]
+            },
+            "uri": "http://www.geonames.org/2640729/oxford.html"
+          },
+          "description": "We recommend that people who wish to attend the opening register on this page: https://wwww.example.org/register"
+        } 
+      }
+    ]
+  }
+}
+```
+
 ## Issues
 
 Report issues for this extension in the [ocds-extensions repository](https://github.com/open-contracting/ocds-extensions/issues), putting the extension's name in the issue's title.
 
 ## Changelog
+
+### 2023-02-13
+
+* Add `Lot.bidOpening`.
 
 ### 2020-04-24
 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ In the European Union, this extension's fields correspond to [eForms BT-132 (Pub
             "uri": "http://www.geonames.org/2640729/oxford.html"
           },
           "description": "We recommend that people who wish to attend the opening register on this page: https://wwww.example.org/register"
-        } 
+        }
       }
     ]
   }

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ In the European Union, this extension's fields correspond to [eForms BT-132 (Pub
   "tender": {
     "lots": [
       {
+        "id": "1",
         "bidOpening": {
           "date": "2019-10-16T15:00:00+01:00",
           "address": {

--- a/extension.json
+++ b/extension.json
@@ -19,7 +19,7 @@
   ],
   "testDependencies": [
     "https://raw.githubusercontent.com/open-contracting-extensions/ocds_lots_extension/master/extension.json"
-  ]
+  ],
   "contactPoint": {
     "name": "Open Contracting Partnership",
     "email": "data@open-contracting.org"

--- a/extension.json
+++ b/extension.json
@@ -15,7 +15,8 @@
     "release-schema.json"
   ],
   "dependencies": [
-    "https://raw.githubusercontent.com/open-contracting-extensions/ocds_location_extension/master/extension.json"
+    "https://raw.githubusercontent.com/open-contracting-extensions/ocds_location_extension/master/extension.json",
+    "https://raw.githubusercontent.com/open-contracting-extensions/ocds_lots_extension/master/extension.json"
   ],
   "contactPoint": {
     "name": "Open Contracting Partnership",

--- a/extension.json
+++ b/extension.json
@@ -15,9 +15,11 @@
     "release-schema.json"
   ],
   "dependencies": [
-    "https://raw.githubusercontent.com/open-contracting-extensions/ocds_location_extension/master/extension.json",
-    "https://raw.githubusercontent.com/open-contracting-extensions/ocds_lots_extension/master/extension.json"
+    "https://raw.githubusercontent.com/open-contracting-extensions/ocds_location_extension/master/extension.json"
   ],
+  "testDependencies": [
+    "https://raw.githubusercontent.com/open-contracting-extensions/ocds_lots_extension/master/extension.json"
+  ]
   "contactPoint": {
     "name": "Open Contracting Partnership",
     "email": "data@open-contracting.org"

--- a/release-schema.json
+++ b/release-schema.json
@@ -9,6 +9,15 @@
         }
       }
     },
+    "Lot": {
+      "properties": {
+        "bidOpening": {
+          "title": "Bid opening",
+          "description": "The date, time, place and other details of the bid opening.",
+          "$ref": "#/definitions/BidOpening"
+        }
+      }
+    },
     "BidOpening": {
       "title": "Bid opening",
       "description": "The date, time, place and other details of the bid opening.",


### PR DESCRIPTION
@jpmckinney should we add some guidance to the documentation to describe when to use `tender.bidOpening` and when to use `tender.lots.bidOpening`? e.g.

> For processes with lots, use `tender.lots.bidOpening`. Otherwise, use `tender.bidOpening`